### PR TITLE
Django Tutorial Part 4: Django admin site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env/
 *.pyc
 .env
+pull_request_template.md

--- a/catalog/admin.py
+++ b/catalog/admin.py
@@ -1,3 +1,40 @@
 from django.contrib import admin
+from .models import Author, Genre, Book, BookInstance
 
-# Register your models here.
+admin.site.register(Genre)
+
+
+class AuthorAdmin(admin.ModelAdmin):
+    list_display = (
+        'last_name',
+        'first_name',
+        'date_of_birth',
+        'date_of_death')
+    fields = ['first_name', 'last_name', ('date_of_birth', 'date_of_death')]
+
+
+admin.site.register(Author, AuthorAdmin)
+
+
+class BooksInstanceInline(admin.TabularInline):
+    model = BookInstance
+    extra = 0  # (tùy chọn) không tạo sẵn dòng trống mới
+
+
+@admin.register(Book)
+class BookAdmin(admin.ModelAdmin):
+    list_display = ('title', 'author', 'display_genre')
+    inlines = [BooksInstanceInline]
+
+
+@admin.register(BookInstance)
+class BookInstanceAdmin(admin.ModelAdmin):
+    llist_filter = ('status', 'due_back')
+    fieldsets = (
+        (None, {
+            'fields': ('book', 'imprint', 'id')
+        }),
+        ('Availability', {
+            'fields': ('status', 'due_back')
+        }),
+    )

--- a/catalog/constants.py
+++ b/catalog/constants.py
@@ -4,8 +4,8 @@ MAX_LENGTH_SUMMARY = 1000
 MAX_LENGTH_ISBN = 13
 MAX_LENGTH_IMPRINT = 200
 LOAN_STATUS = (
-        ('m', 'Maintenance'),
-        ('o', 'On loan'),
-        ('a', 'Available'),
-        ('r', 'Reserved'),
-    )
+    ('m', 'Maintenance'),
+    ('o', 'On loan'),
+    ('a', 'Available'),
+    ('r', 'Reserved'),
+)

--- a/catalog/models.py
+++ b/catalog/models.py
@@ -2,11 +2,17 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 import uuid  # Required for unique book instances
-from .constants import MAX_LENGTH_TITLE, MAX_LENGTH_NAME, MAX_LENGTH_SUMMARY, MAX_LENGTH_ISBN, MAX_LENGTH_IMPRINT,LOAN_STATUS
+from .constants import MAX_LENGTH_TITLE, MAX_LENGTH_NAME, MAX_LENGTH_SUMMARY, MAX_LENGTH_ISBN, MAX_LENGTH_IMPRINT, LOAN_STATUS
 # Create your models here.
+
+
 class Genre (models. Model):
     """Model representing a book genre."""
-    name = models. CharField (max_length=MAX_LENGTH_NAME, help_text=_('Enter a book genre (e.g.Science Fiction)'))
+    name = models. CharField(
+        max_length=MAX_LENGTH_NAME,
+        help_text=_('Enter a book genre (e.g.Science Fiction)'))
+
+
 def _str_(self):
     """String for representing the Model object."""
     return self.name
@@ -16,14 +22,13 @@ class Book(models.Model):
     """Model representing a book (but not a specific copy of a book)."""
     title = models.CharField(max_length=MAX_LENGTH_TITLE)
     author = models.ForeignKey('Author', on_delete=models.RESTRICT, null=True)
-    summary = models.TextField(max_length=MAX_LENGTH_SUMMARY, help_text=_('Enter a brief description of the book'))
-    isbn = models.CharField(
-        'ISBN',
-        max_length=MAX_LENGTH_ISBN,
-        unique=True,
-        help_text=_('13 Character <a href="https://www.isbn-international.org/content/what-isbn">ISBN number</a>')
-    )
-    genre = models.ManyToManyField('Genre', help_text=_('Select a genre for this book'))
+    summary = models.TextField(
+        max_length=MAX_LENGTH_SUMMARY,
+        help_text=_('Enter a brief description of the book'))
+    isbn = models.CharField('ISBN', max_length=MAX_LENGTH_ISBN, unique=True, help_text=_(
+        '13 Character <a href="https://www.isbn-international.org/content/what-isbn">ISBN number</a>'))
+    genre = models.ManyToManyField(
+        'Genre', help_text=_('Select a genre for this book'))
 
     def __str__(self):
         """String for representing the Model object."""
@@ -33,18 +38,21 @@ class Book(models.Model):
         """Returns the url to access a detail record for this book."""
         return reverse('book-detail', args=[str(self.id)])
 
+    def display_genre(self):
+        """Create a string for the Genre. This is required to display genre in Admin."""
+        return ', '.join(genre.name for genre in self.genre.all()[:3])
+
+    display_genre.short_description = 'Genre'
+
+
 class BookInstance(models.Model):
     """Model representing a specific copy of a book (i.e. that can be borrowed from the library)."""
 
-    id = models.UUIDField(
-        primary_key=True,
-        default=uuid.uuid4,
-        help_text=_('Unique ID for this particular book across the whole library')
-    )
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, help_text=_(
+        'Unique ID for this particular book across the whole library'))
     book = models.ForeignKey('Book', on_delete=models.RESTRICT)
-    imprint = models.CharField(max_length=MAX_LENGTH_IMPRINT )
+    imprint = models.CharField(max_length=MAX_LENGTH_IMPRINT)
     due_back = models.DateField(null=True, blank=True)
-
 
     status = models.CharField(
         max_length=1,
@@ -60,6 +68,7 @@ class BookInstance(models.Model):
     def __str__(self):
         """String for representing the Model object."""
         return f'{self.id} ({self.book.title})'
+
 
 class Author(models.Model):
     """Model representing an author."""


### PR DESCRIPTION
## WHAT (optional)
- Configure the Django admin for the Author, Book, and BookInstance models.

## HOW
Use @admin.register to register the model.

Add list_display and fieldsets to the BookInstance admin configuration.

Define a display_genre method to display genre names in BookAdmin.

Use an inline class to display related BookInstance records within the Book admin page.

## Evidence (Screenshot or Video)
<img width="612" height="33" alt="Screen Shot 2025-07-15 at 16 09 41" src="https://github.com/user-attachments/assets/d7c0bb15-7fe2-49d1-8b04-928c858e9a51" />


